### PR TITLE
Allow searching without 0x

### DIFF
--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -13,6 +13,7 @@
 import { ROUTES as r } from '../config/types'
 import { mapState, mapGetters, mapActions } from 'vuex'
 import CtrlSearch from './controls/CtrlSearch'
+import { normalizeSearch } from '../lib/js/utils'
 // const RESULTS_LENGTH = 10
 export default {
   name: 'search-box',
@@ -99,6 +100,7 @@ export default {
     onInput ({ event, value }) {
       this.clearRequests()
       if (!value || value.length < 2) return
+      value = normalizeSearch(value)
       this.setValue(value)
       this.fetchSearch({ value })
     },

--- a/src/lib/js/utils.js
+++ b/src/lib/js/utils.js
@@ -1,4 +1,4 @@
-import { add0x, isHexString } from '@rsksmart/rsk-utils/dist/strings'
+import { add0x, isHexString, isTxOrBlockHash } from '@rsksmart/rsk-utils/dist/strings'
 import { isAddress } from '@rsksmart/rsk-utils/dist/addresses'
 
 export { add0x, isHexString, isAddress }
@@ -9,8 +9,8 @@ export const getType = (obj) => {
 
 export const normalizeSearch = value => {
   value = String(value).toLowerCase()
-  value = (parseInt(value).toString() === Number(value).toString()) ? value : add0x(value)
-  return value
+  const lcValue = add0x(value)
+  return (isAddress(value) || (isHexString(value) && isTxOrBlockHash(lcValue))) ? lcValue : value
 }
 
 export const plainObjectChanges = (oldObj, newObj) => {

--- a/src/store/modules/search/actions.js
+++ b/src/store/modules/search/actions.js
@@ -1,6 +1,6 @@
 
 import { testSearchedValue } from '../../../lib/js/validate'
-import { isHexString, isTxOrBlockHash } from '@rsksmart/rsk-utils/dist/strings'
+import { normalizeSearch } from '../../../lib/js/utils'
 const DEFAULT_TYPE = 'addressByName'
 
 const createSearchKey = (value, type) => {
@@ -16,8 +16,7 @@ export const clearSearchedResults = async ({ commit, dispatch, getters }) => {
 
 export const updateSearchedValue = async ({ commit, dispatch, state }, value) => {
   value = String(value).replace(/[\W_]+/g, '')
-  const lcValue = value.toLowerCase()
-  value = (isHexString(value) && isTxOrBlockHash(lcValue)) ? lcValue : value
+  value = normalizeSearch(value)
   if (state.value !== value) {
     commit('SET_SEARCH_VALUE', value)
     await dispatch('clearSearchedResults')


### PR DESCRIPTION
### Description

Allows searching hexadecimal valid values without `0x` prefix

### Current Behaviour

It redirects to Not Found page when searching valid address or tx hash values without `0x` prefix

### New Behaviour

It redirects to the target page when searching values without `0x` prefix from search bar

Testnet preview: https://rsk-explorer.vercel.app/tx/b8162426d80cb9a0216abfbc538128389939b8c7695adfd7ff9846c0811892c1