### PR TITLE
Display paidFees in block table

### DIFF
--- a/src/config/entities/block.js
+++ b/src/config/entities/block.js
@@ -72,6 +72,10 @@ const Block = () => {
       default: 0,
       trim: 'forced-auto'
     },
+    paidFees: {
+      filters: ['tx-gas-price', 'rbtc'],
+      default: 0
+    },
     time: {
       field: '_metadata.time',
       suffix: 's'


### PR DESCRIPTION
### Description

Displays the amount of `paidFees` corresponding to the sum of all transaction fees in the block.

Testnet preview: https://rsk-explorer.vercel.app/block/2290805