### PR TITLE
Fix/input search

### DIFF
--- a/src/components/Search/CtrlSearch.vue
+++ b/src/components/Search/CtrlSearch.vue
@@ -84,8 +84,7 @@ export default {
       this.selectResult(0)
       const value = event.target.value
       this.value = value
-      const typeEvent = type
-      this.emit(event, typeEvent, value)
+      this.emit(event, type, value)
     },
     emit (event, type, value) {
       type = type || event.type

--- a/src/components/Search/SearchBox.vue
+++ b/src/components/Search/SearchBox.vue
@@ -91,15 +91,18 @@ export default {
       this.value = value
       if (this.isSearchPage) {
         history.pushState({}, document.title, value)
+        console.log('history: ', history)
       }
     },
 
     onResult ({ event, value }) {
+      console.log('value: onResult', value)
       this.setValue(value)
       // if (value) this.clearRequests()
     },
     onInput ({ event, value }) {
       this.clearRequests()
+      console.log('!value || value.length < 2: ', !value || value.length < 2)
       if (!value || value.length < 2) return
       this.setValue(value)
       this.fetchSearch({ value })

--- a/src/components/Search/SearchBox.vue
+++ b/src/components/Search/SearchBox.vue
@@ -15,7 +15,6 @@
 import { ROUTES as r } from '../../config/types'
 import { mapState, mapGetters, mapActions } from 'vuex'
 import CtrlSearch from './CtrlSearch.vue'
-// const RESULTS_LENGTH = 10
 export default {
   name: 'search-box',
   components: {
@@ -91,18 +90,13 @@ export default {
       this.value = value
       if (this.isSearchPage) {
         history.pushState({}, document.title, value)
-        console.log('history: ', history)
       }
     },
-
     onResult ({ event, value }) {
-      console.log('value: onResult', value)
       this.setValue(value)
-      // if (value) this.clearRequests()
     },
     onInput ({ event, value }) {
       this.clearRequests()
-      console.log('!value || value.length < 2: ', !value || value.length < 2)
       if (!value || value.length < 2) return
       this.setValue(value)
       this.fetchSearch({ value })

--- a/src/components/Transactions/LastTransactions.vue
+++ b/src/components/Transactions/LastTransactions.vue
@@ -76,7 +76,10 @@ export default {
       if (this.lastTransactions?.length > 0) {
         this.updateTxs(this.lastTransactions)
       }
-      const value = this.lastTransactions?.length > 0 ? this.lastTransactions : this.lastTxsStore
+      let value = this.lastTransactions?.length > 0 ? this.lastTransactions : this.lastTxsStore
+      if (value[0]?.blockNumber > this.blocks[0]?.number) {
+        value = value.filter((v) => v.blockNumber !== value[0]?.blockNumber)
+      }
       return value
     }
   },

--- a/src/components/home/Block/LastBlock.vue
+++ b/src/components/home/Block/LastBlock.vue
@@ -57,17 +57,6 @@ export default {
       const field = this.fields.number
       const value = this.block.number
       return this.filterFieldValue()({ field, value })
-    },
-    blockColor () {
-      return this.getBlockColor(this.block.number)
-    },
-    bStyle () {
-      const color = this.blockColor
-      return { color, fill: color }
-    },
-    blockBoxStyle () {
-      const color = this.blockColor
-      return { 'border-color': color }
     }
   }
 }

--- a/src/components/home/Block/LastBlocks.vue
+++ b/src/components/home/Block/LastBlocks.vue
@@ -71,8 +71,12 @@ export default {
     ]),
     handleAutoUpdate (event) {
       const value = event.target.checked
+      if (value) this.updateBlocks()
       this.setAutoUpdate(value)
     }
+  },
+  created () {
+    this.updateBlocks()
   }
 }
 </script>

--- a/src/store/modules/backend/actions.js
+++ b/src/store/modules/backend/actions.js
@@ -35,7 +35,8 @@ export const socketNewBlocks = ({ state, commit, getters, dispatch, rootState },
   const autoUpdate = getters.autoUpdate
   commit('LAST_BLOCKS', blocks)
   if (rootState.autoUpdateBlocks) dispatch('updateBlocks')
-  if (rootState.route.path === '/') {
+  if (rootState.route.path === '/' && autoUpdate) {
+    commit('LAST_BLOCKS_TIME', blocks[0].timestamp)
     dispatch('fetchRouteData', { action: 'getTransactions', params: undefined, module: 'transactions', key: 'data' })
   }
   if (!state.lastBlocksTime) commit('LAST_BLOCKS_TIME')

--- a/src/store/modules/backend/mutations.js
+++ b/src/store/modules/backend/mutations.js
@@ -19,8 +19,7 @@ export const LAST_BLOCKS = (state, blocks) => {
 }
 
 export const LAST_BLOCKS_TIME = (state, time) => {
-  if (undefined === time) time = Date.now()
-  state.lastBlocksTime = time
+  state.lastBlocksTime = time ? new Date(time * 1000) : Date.now()
 }
 export const SET_BLOCKS = (state, blocks) => {
   state.blocks = blocks

--- a/src/store/modules/search/actions.js
+++ b/src/store/modules/search/actions.js
@@ -10,12 +10,12 @@ const createSearchKey = (value, type) => {
 export const clearSearchedResults = async ({ commit, dispatch, getters }) => {
   const keys = getters.searchKeysRequested
   commit('CLEAR_SEARCH_REQUEST')
-  await dispatch('clearRequests', keys)
+  // await dispatch('clearRequests', keys)
   return dispatch('clearResponses', keys)
 }
 
 export const updateSearchedValue = async ({ commit, dispatch, state }, value) => {
-  value = String(value).replace(/[\W_]+/g, '')
+  // value = String(value).replace(/[\W_]+/g, '')
   const lcValue = value.toLowerCase()
   value = (isHexString(value) && isTxOrBlockHash(lcValue)) ? lcValue : value
   if (state.value !== value) {

--- a/src/store/modules/search/actions.js
+++ b/src/store/modules/search/actions.js
@@ -10,12 +10,11 @@ const createSearchKey = (value, type) => {
 export const clearSearchedResults = async ({ commit, dispatch, getters }) => {
   const keys = getters.searchKeysRequested
   commit('CLEAR_SEARCH_REQUEST')
-  // await dispatch('clearRequests', keys)
+  await dispatch('clearRequests', keys)
   return dispatch('clearResponses', keys)
 }
 
 export const updateSearchedValue = async ({ commit, dispatch, state }, value) => {
-  // value = String(value).replace(/[\W_]+/g, '')
   const lcValue = value.toLowerCase()
   value = (isHexString(value) && isTxOrBlockHash(lcValue)) ? lcValue : value
   if (state.value !== value) {


### PR DESCRIPTION
# Integrations

- Implement a "debounce" function to optimize requests and not overload the backend.
- Txs are filtered according to the last block
- The functionality that does not allow you to search for more than one word has been eliminated
- The time of the last block is taken to indicate that the counting begins from there