### PR TITLE
fix: avoid the scroll jump and align value

### DIFF
--- a/src/components/DataField.vue
+++ b/src/components/DataField.vue
@@ -19,7 +19,22 @@
         </ul>
       </template>
       <template v-else>
-        <template v-if="trim && !options.noTrim">
+        <template v-if="isTokenTransferTab && IsfieldValue">
+          <div class="content-short-value">
+            <div class="short-value" :class="{'suffix-value' : (filteredValue !== null && suffix)}">
+              {{ shortValue(filteredValue || field.default) }}
+              <div class="full-value" v-if="(filteredValue || field.default).length > 10">
+                <div class="text-value">
+                  {{ filteredValue || field.default }}
+                </div>
+              </div>
+            </div>
+            <div class="field-suffix" v-if="filteredValue !== null && suffix">
+              &nbsp;{{ suffix }}
+            </div>
+          </div>
+        </template>
+        <template v-else-if="trim && !options.noTrim">
           <tool-tip class="field-value" :value="filteredValue || value" :trim="trim" :options="trimOptions" :router-link="link"></tool-tip>
         </template>
         <template v-else>
@@ -28,7 +43,7 @@
           </router-link>
           <div class="field-value" v-else>{{ filteredValue || field.default }}</div>
         </template>
-        <span class="field-suffix" v-if="suffix && filteredValue !== null">&nbsp; {{ suffix }}</span>
+        <span class="field-suffix" v-if="suffix && filteredValue !== null && !isTokenTransferTab">&nbsp; {{ suffix }}</span>
         <field-icon class="field-value-description" v-if="valueDescription" icon="help" :title="valueDescription"></field-icon>
         <progress-bar v-if="delayed"></progress-bar>
       </template>
@@ -41,6 +56,7 @@ import dataMixin from '../mixins/dataMixin'
 import { getType } from '../lib/js/utils'
 import ProgressBar from './controls/ProgressBar'
 import FieldIcon from './FieldIcon'
+import { mapGetters } from 'vuex'
 export default {
   name: 'data-field',
   components: {
@@ -64,9 +80,15 @@ export default {
     delayed: {
       type: Boolean,
       default: false
+    },
+    fieldClassName: {
+      required: false
     }
   },
   computed: {
+    ...mapGetters({
+      getActiveTab: 'getActiveTab'
+    }),
     filteredValue () {
       const { field, value, row } = this
       return this.filterFieldValue()({ field, value, data: row })
@@ -98,7 +120,76 @@ export default {
     },
     valueDescription () {
       return this.fieldValueDescription(this.field, this.value, this.filteredValue, this.row)
+    },
+    isTokenTransferTab () {
+      return this.getActiveTab === 'tokens transfers'
+    },
+    IsfieldValue () {
+      if (!Array.isArray(this.fieldClassName)) return null
+      return this.fieldClassName[0] === 'field__value'
+    }
+  },
+  methods: {
+    shortValue (value) {
+      if (value.length > 10) return `${value.substring(0, 10)}...`
+      return value
+    }
+  },
+  created () {
+    if (this.getActiveTab === 'tokens transfers') {
+      this.options.trimAt = 'right'
     }
   }
 }
 </script>
+<style scoped lang="scss">
+@import '@/styles/variables';
+.content-short-value, .short-value {
+  display: flex;
+  position: relative;
+}
+.content-short-value {
+  width: 130px;
+  justify-content: flex-end;
+  .field-suffix {
+    display: flex;
+    justify-content: flex-end;
+  }
+  .short-value {
+    display: flex;
+    justify-content: flex-end;
+    &.suffix-value {
+      justify-content: flex-end;
+    }
+  }
+}
+
+.short-value div.full-value {
+  display: none;
+  position: absolute;
+  background-color: $newbw_900;
+  padding: 5px;
+  z-index: 1;
+  color: $white_400;
+  width: max-content;
+  max-width: max-content;
+  word-wrap: break-word;
+  height: max-content;
+  font-size: 14px;
+  bottom: 20px;
+  border-radius: 5px;
+  &::after {
+    border-width: 5px;
+    border: solid transparent;
+    content: ' ';
+    height: 0;
+    width: 0;
+    position: absolute;
+    z-index: 100;
+}
+}
+
+.short-value:hover div.full-value {
+  display: block;
+}
+</style>

--- a/src/components/General/DataTable.vue
+++ b/src/components/General/DataTable.vue
@@ -77,7 +77,7 @@
               <template v-if="getCustomRenderProps(field, row)">
                 <component :is="field.renderAs" v-bind="getCustomRenderProps(field, row)"></component>
               </template>
-              <data-field v-else :field="field" :row="row" />
+              <data-field :fieldClassName="tdClass(fieldName)" v-else :field="field" :row="row" />
             </td>
             <td class="from-to-arrow" v-if="isFrom(fieldName, index)" :key="`5-${index}`">
               <icon name="arrow-right"></icon>

--- a/src/config/entities/event.js
+++ b/src/config/entities/event.js
@@ -173,9 +173,9 @@ export const TransferEvents = () => {
       },
       from,
       to,
-      value,
       date,
-      created
+      created,
+      value
     },
     formatRow: ({ data, parentData, context }) => {
       const { _addressData, address } = data

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -11,19 +11,11 @@ Vue.use(Router)
 const router = new Router({
   mode: 'history',
   scrollBehavior (to, from, savedPosition) {
-    let x = 0
-    let y = 0
-    if (savedPosition) {
-      return savedPosition
-    } else {
-      let hash = to.hash
-      if (hash) {
-        hash = hash.split(':')
-        x = hash[0]
-        y = hash[1]
-      }
-      return { x, y }
-    }
+    const toBasePath = to.path.split('/')[1]
+    const fromBasePath = from.path.split('/')[1]
+    if (toBasePath === fromBasePath) return false
+    if (savedPosition) return savedPosition
+    return { x: 0, y: 0 }
   },
   routes
 })


### PR DESCRIPTION
- avoid the scroll jump when you are on the same page
- the values ​​in the token transfers tab are aligned

![image](https://github.com/rsksmart/rsk-explorer/assets/149804324/8aea77d2-10c0-42b5-992b-6c9b559cec71)
